### PR TITLE
Add After=postgresql.service to unit service

### DIFF
--- a/misc/multistreamer.service
+++ b/misc/multistreamer.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=multistreamer
 After=network.target
+After=postgresql.service
 
 [Service]
 ExecStart=/opt/multistreamer/bin/multistreamer -c /etc/multistreamer/config.yaml run


### PR DESCRIPTION
In some cases, if postgresql is not up or in the processing of starting up, multistreamer service unit will fail to start.

E.g:

Connection refused
Database is starting up