### PR TITLE
FB musical chairs replaces the manage_pages and publish_pages scopes

### DIFF
--- a/lib/multistreamer/networks/facebook.lua
+++ b/lib/multistreamer/networks/facebook.lua
@@ -111,7 +111,7 @@ function M.get_oauth_url(user, stream_id)
       state = encode_base64(encode_with_secret({ id = user.id, stream_id = stream_id })),
       redirect_uri = M.redirect_uri,
       client_id = facebook_config.app_id,
-      scope = 'publish_video,pages_manage_metadata,pages_read_engagement,pages_read_user_content,pages_manage_posts,pages_manage_engagement'
+      scope = 'publish_video,pages_manage_metadata,pages_read_engagement,pages_read_user_content,pages_manage_posts,pages_manage_engagement',
     })
 end
 

--- a/lib/multistreamer/networks/facebook.lua
+++ b/lib/multistreamer/networks/facebook.lua
@@ -111,7 +111,7 @@ function M.get_oauth_url(user, stream_id)
       state = encode_base64(encode_with_secret({ id = user.id, stream_id = stream_id })),
       redirect_uri = M.redirect_uri,
       client_id = facebook_config.app_id,
-      scope = 'publish_video,manage_pages,publish_pages',
+      scope = 'publish_video,pages_manage_metadata,pages_read_engagement,pages_read_user_content,pages_manage_posts,pages_manage_engagement'
     })
 end
 


### PR DESCRIPTION
https://developers.facebook.com/docs/facebook-login/permissions/#reference-manage_pages

Existing users of `manage_pages` will not be affected, but new users like myself are getting errors that `manage_pages` does not exist. FB is forcing everyone to migrate to the new granular scopes.